### PR TITLE
Take result of find and make boolean

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,9 +124,9 @@ function setHooks (inst) {
   }
 
   function isAMentionOfUser (record) {
-    return record.hasOwnProperty('mentions') && record.mentions.find(x => {
+    return record.hasOwnProperty('mentions') && !(record.mentions.find(x => {
       return x.url == inst.userUrl
-    })
+    }) == undefined)
   }
 
   async function isNotificationIndexed (url) {


### PR DESCRIPTION
Take the result of find and make it true/false rather than the found value or undefined if there isn't a match.

Provides a fix for https://github.com/beakerbrowser/fritter/issues/17