### PR TITLE
Add optional createdAt parameter when creating post

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,8 @@ await fritter.feed.post(alice, {
 await fritter.feed.post(alice, {
   text: 'Hello, world!',
   threadParent: parent.getRecordURL(), // url of message replying to
-  threadRoot: root.getRecordURL() // url of topmost ancestor message
+  threadRoot: root.getRecordURL(), // url of topmost ancestor message
+  createdAt: Date.parse('04 Dec 2017 00:12:00 GMT') // optional 
 })
 ```
 

--- a/lib/feed.js
+++ b/lib/feed.js
@@ -13,7 +13,7 @@ class LibFritterFeedAPI {
   async post (archive, {text, threadRoot, threadParent, mentions, createdAt}) {
     const archiveUrl = toArchiveOrigin(archive)
     const url = `${archiveUrl}/posts/${newID()}.json`
-    if (createdAt == null) {
+    if (typeof createdAt === 'undefined') {
       createdAt = Date.now()
     }
     await this.db.posts.put(url, {text, threadRoot, threadParent, createdAt, mentions})

--- a/lib/feed.js
+++ b/lib/feed.js
@@ -10,10 +10,12 @@ class LibFritterFeedAPI {
     this.db = libfritter.db
   }
 
-  async post (archive, {text, threadRoot, threadParent, mentions}) {
+  async post (archive, {text, threadRoot, threadParent, mentions, createdAt}) {
     const archiveUrl = toArchiveOrigin(archive)
-    const createdAt = Date.now()
     const url = `${archiveUrl}/posts/${newID()}.json`
+    if (createdAt == null) {
+      createdAt = Date.now()
+    }
     await this.db.posts.put(url, {text, threadRoot, threadParent, createdAt, mentions})
     return url
   }


### PR DESCRIPTION
This PR adds an optional parameter `createdAt` to the `fritter.feed.post` API. I don't know if you plan on including this functionality in the library, but I added it in order to import Twitter archives to Fritter (see dat://twitter-go-fritter.001.land). Thought I might as well make it a PR.

all the best,
Vincent